### PR TITLE
behaves_like on right line + Fix

### DIFF
--- a/lua/ror/test/rspec.lua
+++ b/lua/ror/test/rspec.lua
@@ -133,10 +133,13 @@ function M.run(test_path, bufnr, ns, terminal_bufnr, notify_record)
 
             local fail_backtrace = filter_backtrace(decoded.exception.backtrace)[1]
             local example_line
+            local exception_message
 
             if is_shared_example then
+              exception_message = (decoded.description or '') .. ': ' .. decoded.exception.message
               example_line = find_behaves_like_line(decoded)
             else
+              exception_message = decoded.exception.message
               example_line = string.match(fail_backtrace, ":([^:]+)")
             end
 
@@ -150,7 +153,7 @@ function M.run(test_path, bufnr, ns, terminal_bufnr, notify_record)
               col = 0,
               severity = vim.diagnostic.severity.ERROR,
               source = "rspec",
-              message = decoded.exception.message,
+              message = exception_message,
               user_data = {},
             })
           end

--- a/lua/ror/test/rspec.lua
+++ b/lua/ror/test/rspec.lua
@@ -126,9 +126,8 @@ function M.run(test_path, bufnr, ns, terminal_bufnr, notify_record)
       M.summary = result.summary
 
       for _, decoded in ipairs(result.examples) do
-
         if decoded.file_path ~= nil and decoded.file_path ~= "" then
-          local is_shared_example = not (decoded.file_path:find(test_path))
+          local is_shared_example = not(string.find(decoded.file_path, vim.fn.fnamemodify(test_path, ":t:r")) ~= nil)
 
           if decoded.status == "passed" then
             local text = { config.pass_icon }

--- a/lua/ror/test/rspec.lua
+++ b/lua/ror/test/rspec.lua
@@ -136,7 +136,7 @@ function M.run(test_path, bufnr, ns, terminal_bufnr, notify_record)
             local exception_message
 
             if is_shared_example then
-              exception_message = (decoded.description or '') .. ': ' .. decoded.exception.message
+              exception_message = (decoded.description or '') .. ' at ' .. (decoded.line_number or '') .. ': ' .. decoded.exception.message
               example_line = find_behaves_like_line(decoded)
             else
               exception_message = decoded.exception.message


### PR DESCRIPTION
Fixes https://github.com/weizheheng/ror.nvim/issues/15 (last comment).  Add it_behaves_like support.

<img width="990" alt="image" src="https://user-images.githubusercontent.com/9551316/202452204-5496c10c-882a-4b83-ae28-194236b681e1.png">


<img width="617" alt="image" src="https://user-images.githubusercontent.com/9551316/202452112-a60ad2ce-c287-431c-a4b7-f70febfb61cc.png">

spec name as prefix:
<img width="688" alt="image" src="https://user-images.githubusercontent.com/9551316/202463337-f77ba9c4-b726-46a0-aff1-750545003a2b.png">

