### PR TITLE
Correctly detect rdbg prompt when parallel testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ require("ror").setup({
 vim.keymap.set("n", "<Leader>rc", ":lua require('ror.commands').list_commands()<CR>", { silent = true })
 ```
 
+## LunarVim
+```lua
+-- Set a keybind
+lvim.builtin.which_key.mappings["r"] = {
+    name = "Ruby on Rails",
+    c = { "<cmd>lua require('ror.commands').list_commands()<cr>", "RoR Menu" },
+}
+```
+
 ## Features
 
 ### 1. Test Helpers

--- a/lua/ror/test.lua
+++ b/lua/ror/test.lua
@@ -25,7 +25,7 @@ local function verify_debugger()
 
     if last_line == '[Process exited 1]' or vim.fn.bufnr() == M.terminal_bufnr then
       return
-    elseif last_line:match('%(byebug%)') or last_line:match('pry%(#.*%)') or last_line:match('%(rdbg%)') or last_line == ':' then
+    elseif last_line:match('%(byebug%)') or last_line:match('pry%(#.*%)') or last_line:match('%(rdbg[%)@]') or last_line == ':' then
       M.attach_terminal()
       vim.cmd("startinsert")
     else


### PR DESCRIPTION
When tests are run in parallel instead of the standard `(rdbg)` prompt it's also decorated with the stopped process ID. This change allows the prompt to be detected by checking for `[%)@]` at the end  so should properly detect `(rdbg@rails_test#84025)`