### PR TITLE
Feat: snacks picker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Plug 'weizheheng/ror.nvim'
 ```
 
 ## Dependencies
-1. [telescope](https://github.com/nvim-telescope/telescope.nvim)
+
+Choose one of the following picker backends:
+
+1. [telescope](https://github.com/nvim-telescope/telescope.nvim) (default)
+2. [snacks.nvim](https://github.com/folke/snacks.nvim) (requires `snacks.picker`)
 
 ## Optional Dependencies
 
@@ -37,6 +41,7 @@ require("dressing").setup({
 ```lua
 -- The default settings
 require("ror").setup({
+  -- picker = "telescope", -- default, or "snacks" to use snacks.picker
   test = {
     message = {
       -- These are the default title for nvim-notify

--- a/lua/ror/config.lua
+++ b/lua/ror/config.lua
@@ -40,6 +40,7 @@ local config = {}
 config.values = _RorConfig
 
 local ror_defaults = {
+  picker = "telescope",
   test = {
     message = {
       file = "Running test file",

--- a/lua/ror/finders/controller.lua
+++ b/lua/ror/finders/controller.lua
@@ -1,30 +1,19 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local controllers = vim.split(vim.fn.glob(root_path .. "/app/controllers/**/*rb"), "\n")
   local parsed_controllers = {}
   for _, value in ipairs(controllers) do
-    -- take only the filename without extension
     if value ~= "" then
       local parsed_filename = vim.fn.fnamemodify(value, ":~:.")
       table.insert(parsed_controllers, parsed_filename)
     end
   end
 
-  local opts = {}
-  pickers.new(opts, {
-    prompt_title = "Controllers",
-    finder = finders.new_table {
-      results = parsed_controllers
-    },
-    previewer = previewers.vim_buffer_cat.new(opts),
-    sorter = conf.generic_sorter(opts),
-  }):find()
+  if #parsed_controllers > 0 then
+    require("ror.picker").pick("Controllers", parsed_controllers)
+  end
 end
 
 return M

--- a/lua/ror/finders/controller_test.lua
+++ b/lua/ror/finders/controller_test.lua
@@ -1,15 +1,10 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local tests = vim.split(vim.fn.glob(root_path .. "/test/controllers/**/*rb"), "\n")
   local parsed_tests = {}
   for _, test in ipairs(tests) do
-    -- take only the filename without extension
     if test ~= "" then
       local parsed_test = vim.fn.fnamemodify(test, ":~:.")
       table.insert(parsed_tests, parsed_test)
@@ -17,15 +12,7 @@ function M.find()
   end
 
   if #parsed_tests > 0 then
-    local opts = {}
-    pickers.new(opts, {
-      prompt_title = "Controller tests",
-      finder = finders.new_table {
-        results = parsed_tests
-      },
-      previewer = previewers.vim_buffer_cat.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    require("ror.picker").pick("Controller tests", parsed_tests)
   end
 end
 

--- a/lua/ror/finders/mailer.lua
+++ b/lua/ror/finders/mailer.lua
@@ -1,30 +1,19 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local mailers = vim.split(vim.fn.glob(root_path .. "/app/mailers/**/*rb"), "\n")
   local parsed_mailers = {}
   for _, value in ipairs(mailers) do
-    -- take only the filename without extension
     if value ~= "" then
       local parsed_filename = vim.fn.fnamemodify(value, ":~:.")
       table.insert(parsed_mailers, parsed_filename)
     end
   end
 
-  local opts = {}
-  pickers.new(opts, {
-    prompt_title = "Mailers",
-    finder = finders.new_table {
-      results = parsed_mailers
-    },
-    previewer = previewers.vim_buffer_cat.new(opts),
-    sorter = conf.generic_sorter(opts),
-  }):find()
+  if #parsed_mailers > 0 then
+    require("ror.picker").pick("Mailers", parsed_mailers)
+  end
 end
 
 return M

--- a/lua/ror/finders/migration.lua
+++ b/lua/ror/finders/migration.lua
@@ -1,31 +1,18 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local migrations = vim.split(vim.fn.glob(root_path .. "/db/migrate/*rb"), "\n")
   local parsed_migrations = {}
   for i = #migrations, 1, -1 do
     if migrations[i] ~= "" then
-      -- take only the filename without extension
       local parsed_filename = vim.fn.fnamemodify(migrations[i], ":~:.")
       table.insert(parsed_migrations, parsed_filename)
     end
   end
 
   if #parsed_migrations > 0 then
-    local opts = {}
-    pickers.new(opts, {
-      prompt_title = "DB Migrations",
-      finder = finders.new_table {
-        results = parsed_migrations
-      },
-      previewer = previewers.vim_buffer_cat.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    require("ror.picker").pick("DB Migrations", parsed_migrations)
   end
 end
 

--- a/lua/ror/finders/model.lua
+++ b/lua/ror/finders/model.lua
@@ -1,16 +1,10 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
-
   local root_path = vim.fn.getcwd()
   local models = vim.split(vim.fn.glob(root_path .. "/app/models/**/*rb"), "\n")
   local parsed_models = {}
   for _, value in ipairs(models) do
-    -- take only the filename without extension
     if value ~= "" then
       local parsed_filename = vim.fn.fnamemodify(value, ":~:.")
       table.insert(parsed_models, parsed_filename)
@@ -18,15 +12,7 @@ function M.find()
   end
 
   if #parsed_models > 0 then
-    local opts = {}
-    pickers.new(opts, {
-      prompt_title = "Models",
-      finder = finders.new_table {
-        results = parsed_models
-      },
-      previewer = previewers.vim_buffer_cat.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    require("ror.picker").pick("Models", parsed_models)
   end
 end
 

--- a/lua/ror/finders/model_test.lua
+++ b/lua/ror/finders/model_test.lua
@@ -1,15 +1,10 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local tests = vim.split(vim.fn.glob(root_path .. "/test/models/**/*rb"), "\n")
   local parsed_tests = {}
   for _, test in ipairs(tests) do
-    -- take only the filename without extension
     if test ~= "" then
       local parsed_test = vim.fn.fnamemodify(test, ":~:.")
       table.insert(parsed_tests, parsed_test)
@@ -17,15 +12,7 @@ function M.find()
   end
 
   if #parsed_tests > 0 then
-    local opts = {}
-    pickers.new(opts, {
-      prompt_title = "Model tests",
-      finder = finders.new_table {
-        results = parsed_tests
-      },
-      previewer = previewers.vim_buffer_cat.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    require("ror.picker").pick("Model tests", parsed_tests)
   end
 end
 

--- a/lua/ror/finders/stimulus.lua
+++ b/lua/ror/finders/stimulus.lua
@@ -1,15 +1,10 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local stimulus_controllers = vim.split(vim.fn.glob(root_path .. "/app/javascript/controllers/*js"), "\n")
   local parsed_stimulus_controllers = {}
   for _, stimulus_controller in ipairs(stimulus_controllers) do
-    -- take only the filename without extension
     if stimulus_controller ~= "" then
       local parsed_stimulus_controller = vim.fn.fnamemodify(stimulus_controller, ":~:.")
       table.insert(parsed_stimulus_controllers, parsed_stimulus_controller)
@@ -17,15 +12,7 @@ function M.find()
   end
 
   if #parsed_stimulus_controllers > 0 then
-    local opts = {}
-    pickers.new(opts, {
-      prompt_title = "System tests",
-      finder = finders.new_table {
-        results = parsed_stimulus_controllers
-      },
-      previewer = previewers.vim_buffer_cat.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    require("ror.picker").pick("Stimulus controllers", parsed_stimulus_controllers)
   end
 end
 

--- a/lua/ror/finders/system_test.lua
+++ b/lua/ror/finders/system_test.lua
@@ -1,15 +1,10 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local tests = vim.split(vim.fn.glob(root_path .. "/test/system/**/*rb"), "\n")
   local parsed_tests = {}
   for _, test in ipairs(tests) do
-    -- take only the filename without extension
     if test ~= "" then
       local parsed_test = vim.fn.fnamemodify(test, ":~:.")
       table.insert(parsed_tests, parsed_test)
@@ -17,15 +12,7 @@ function M.find()
   end
 
   if #parsed_tests > 0 then
-    local opts = {}
-    pickers.new(opts, {
-      prompt_title = "System tests",
-      finder = finders.new_table {
-        results = parsed_tests
-      },
-      previewer = previewers.vim_buffer_cat.new(opts),
-      sorter = conf.generic_sorter(opts),
-    }):find()
+    require("ror.picker").pick("System tests", parsed_tests)
   end
 end
 

--- a/lua/ror/finders/view.lua
+++ b/lua/ror/finders/view.lua
@@ -1,15 +1,10 @@
 local M = {}
 
 function M.find()
-  local pickers = require "telescope.pickers"
-  local finders = require "telescope.finders"
-  local previewers = require "telescope.previewers"
-  local conf = require("telescope.config").values
   local root_path = vim.fn.getcwd()
   local views = vim.split(vim.fn.glob(root_path .. "/app/views/**/*.erb"), "\n")
   local parsed_views = {}
   for _, view in ipairs(views) do
-    -- take only the filename without extension
     if view ~= "" then
       local parsed_view = vim.fn.fnamemodify(view, ":~:.")
       table.insert(parsed_views, parsed_view)
@@ -17,15 +12,7 @@ function M.find()
   end
 
   if #parsed_views > 0 then
-    local opts = {}
-    pickers.new(opts, {
-        prompt_title = "Views",
-        finder = finders.new_table {
-          results = parsed_views
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+    require("ror.picker").pick("Views", parsed_views)
   end
 end
 

--- a/lua/ror/navigators/controller.lua
+++ b/lua/ror/navigators/controller.lua
@@ -5,13 +5,10 @@ function M.visit(mode)
 
   if string.match(current_relative_file_path, "/models") then
     local model_name = vim.fn.fnamemodify(current_relative_file_path, ":t:r")
-    -- Can go from model test -> controller
     local start, _ = string.find(model_name, "_test")
     if start ~= nil then
       model_name = string.sub(model_name, 1, start - 1)
     end
-    -- Rails default of pluralizing controller
-    -- Caveat: not working with controller with pluralize name other than adding s
     local parsed_controller_name = "*" .. model_name .. "s_controller.rb"
 
     local controllers = vim.split(vim.fn.system({ "find", "app/controllers", "-name", parsed_controller_name }), "\n")
@@ -23,19 +20,7 @@ function M.visit(mode)
     end
 
     if #parsed_controllers > 1 then
-      local pickers = require "telescope.pickers"
-      local finders = require "telescope.finders"
-      local previewers = require "telescope.previewers"
-      local conf = require("telescope.config").values
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Controllers",
-        finder = finders.new_table {
-          results = parsed_controllers
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Controllers", parsed_controllers)
     elseif #parsed_controllers == 1 then
       if mode == "normal" then
         vim.cmd.edit(parsed_controllers[1])
@@ -56,7 +41,6 @@ function M.visit(mode)
     end
   elseif string.match(current_relative_file_path, "test/controllers") then
     local controller_name = vim.fn.fnamemodify(current_relative_file_path, ":t:r")
-    -- Can go from controller test -> controller
     local start, _ = string.find(controller_name, "_test")
     if start ~= nil then
       controller_name = string.sub(controller_name, 1, start - 1)
@@ -72,19 +56,7 @@ function M.visit(mode)
     end
 
     if #parsed_controllers > 1 then
-      local pickers = require "telescope.pickers"
-      local finders = require "telescope.finders"
-      local previewers = require "telescope.previewers"
-      local conf = require("telescope.config").values
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Controllers",
-        finder = finders.new_table {
-          results = parsed_controllers
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Controllers", parsed_controllers)
     elseif #parsed_controllers == 1 then
       if mode == "normal" then
         vim.cmd.edit(parsed_controllers[1])

--- a/lua/ror/navigators/model.lua
+++ b/lua/ror/navigators/model.lua
@@ -1,17 +1,12 @@
 local M = {}
 
-local pickers = require "telescope.pickers"
-local finders = require "telescope.finders"
-local previewers = require "telescope.previewers"
-local conf = require("telescope.config").values
-
 function M.visit(mode)
   local current_relative_file_path = vim.fn.expand("%:~:.")
 
   if string.match(current_relative_file_path, "/controllers") then
     local file_name = vim.fn.fnamemodify(current_relative_file_path, ":t:r")
     local start, _ = string.find(file_name, "_controller")
-    local model_name = string.sub(file_name, 1, start - 2) -- Removing the last "s"
+    local model_name = string.sub(file_name, 1, start - 2)
     local parsed_model_name = "*" .. model_name .. ".rb"
 
     local models = vim.split(vim.fn.system({ "find", "app/models", "-name", parsed_model_name }), "\n")
@@ -23,15 +18,7 @@ function M.visit(mode)
     end
 
     if #parsed_models > 1 then
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Models",
-        finder = finders.new_table {
-          results = parsed_models
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Models", parsed_models)
     elseif #parsed_models == 1 then
       if mode == "normal" then
         vim.cmd.edit(parsed_models[1])
@@ -52,7 +39,6 @@ function M.visit(mode)
     end
   elseif string.match(current_relative_file_path, "test/models") then
     local model_name = vim.fn.fnamemodify(current_relative_file_path, ":t:r")
-    -- Can go from model test -> controller
     local start, _ = string.find(model_name, "_test")
     if start ~= nil then
       model_name = string.sub(model_name, 1, start - 1)
@@ -68,15 +54,7 @@ function M.visit(mode)
     end
 
     if #parsed_models > 1 then
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Models",
-        finder = finders.new_table {
-          results = parsed_models
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Models", parsed_models)
     elseif #parsed_models == 1 then
       if mode == "normal" then
         vim.cmd.edit(parsed_models[1])

--- a/lua/ror/navigators/test.lua
+++ b/lua/ror/navigators/test.lua
@@ -1,10 +1,5 @@
 local M = {}
 
-local pickers = require "telescope.pickers"
-local finders = require "telescope.finders"
-local previewers = require "telescope.previewers"
-local conf = require("telescope.config").values
-
 function M.visit(mode)
   local current_relative_file_path = vim.fn.expand("%:~:.")
 
@@ -21,15 +16,7 @@ function M.visit(mode)
     end
 
     if #parsed_tests > 1 then
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Model Tests",
-        finder = finders.new_table {
-          results = parsed_tests
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Model Tests", parsed_tests)
     elseif #parsed_tests == 1 then
       if mode == "normal" then
         vim.cmd.edit(parsed_tests[1])
@@ -61,15 +48,7 @@ function M.visit(mode)
     end
 
     if #parsed_tests > 1 then
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Controller Tests",
-        finder = finders.new_table {
-          results = parsed_tests
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Controller Tests", parsed_tests)
     elseif #parsed_tests == 1 then
       if mode == "normal" then
         vim.cmd.edit(parsed_tests[1])

--- a/lua/ror/navigators/view.lua
+++ b/lua/ror/navigators/view.lua
@@ -1,17 +1,11 @@
 local M = {}
 
-local pickers = require "telescope.pickers"
-local finders = require "telescope.finders"
-local previewers = require "telescope.previewers"
-local conf = require("telescope.config").values
-
 function M.visit()
   local root_path = vim.fn.getcwd()
   local current_relative_file_path = vim.fn.expand("%:~:.")
 
   if string.match(current_relative_file_path, "app/models") then
     local model_name = vim.fn.fnamemodify(current_relative_file_path, ":t:r")
-    -- Only works with default directory name with pluralize name (noun with s plural)
     local view_directory = root_path .. "/app/views/" .. model_name .. "s" .."/**/*.html.erb"
 
     local views = vim.split(vim.fn.glob(view_directory), "\n")
@@ -24,15 +18,7 @@ function M.visit()
     end
 
     if #parsed_views > 0 then
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Views",
-        finder = finders.new_table {
-          results = parsed_views
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Views", parsed_views)
     else
       local nvim_notify_ok, nvim_notify = pcall(require, 'notify')
       if nvim_notify_ok then
@@ -48,7 +34,6 @@ function M.visit()
   elseif string.match(current_relative_file_path, "app/controllers") then
     local controller_name = vim.fn.fnamemodify(current_relative_file_path, ":t:r")
     local start, _ = string.find(controller_name, "_controller")
-    -- Remove _controller.rb
     controller_name = string.sub(controller_name, 1, start - 1)
     local view_directory = root_path .. "/app/views/" .. controller_name .."/**/*.html.erb"
 
@@ -62,15 +47,7 @@ function M.visit()
     end
 
     if #parsed_views > 0 then
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = "Views",
-        finder = finders.new_table {
-          results = parsed_views
-        },
-        previewer = previewers.vim_buffer_cat.new(opts),
-        sorter = conf.generic_sorter(opts),
-      }):find()
+      require("ror.picker").pick("Views", parsed_views)
     else
       local nvim_notify_ok, nvim_notify = pcall(require, 'notify')
       if nvim_notify_ok then

--- a/lua/ror/picker.lua
+++ b/lua/ror/picker.lua
@@ -1,0 +1,51 @@
+local M = {}
+
+function M.pick(title, results)
+  local config = require("ror.config")
+  local picker_backend = config.values.picker or "telescope"
+
+  if picker_backend == "snacks" then
+    local ok, snacks = pcall(function()
+      return Snacks.picker
+    end)
+    if ok and snacks then
+      local items = {}
+      for _, path in ipairs(results) do
+        table.insert(items, { text = path, file = path })
+      end
+      snacks.pick({
+        items = items,
+        title = title,
+      })
+      return
+    else
+      vim.notify("snacks.picker not available, falling back to vim.ui.select", vim.log.levels.WARN)
+    end
+  elseif picker_backend == "telescope" then
+    local ok, _ = pcall(require, "telescope")
+    if ok then
+      local pickers = require("telescope.pickers")
+      local finders = require("telescope.finders")
+      local previewers = require("telescope.previewers")
+      local conf = require("telescope.config").values
+      local opts = {}
+      pickers.new(opts, {
+        prompt_title = title,
+        finder = finders.new_table { results = results },
+        previewer = previewers.vim_buffer_cat.new(opts),
+        sorter = conf.generic_sorter(opts),
+      }):find()
+      return
+    else
+      vim.notify("telescope.nvim not available, falling back to vim.ui.select", vim.log.levels.WARN)
+    end
+  end
+
+  vim.ui.select(results, { prompt = title .. ": " }, function(selected)
+    if selected then
+      vim.cmd.edit(selected)
+    end
+  end)
+end
+
+return M


### PR DESCRIPTION
## Problem
`ror.nvim` uses `telescope.nvim` as a hardcoded dependency at 17 call sites across `finders/` and `navigators/`. There is no abstraction layer, each call site copies the same telescope boilerplate. Users who prefer snacks.nvim's picker (`snacks.picker`) have no way to use it.

Introduce a picker wrapper module (`lua/ror/picker.lua`) that centralizes the picker dispatch logic. Users configure their preferred picker backend via `require("ror").setup({ picker = "snacks" })`

## Summary
- Add `snacks.picker` (from [folke/snacks.nvim](https://github.com/folke/snacks.nvim)) as an alternative picker backend alongside telescope
- Introduce a picker wrapper module (`lua/ror/picker.lua`) that centralizes all picker dispatch logic
- Replace all 17 inline telescope calls across 13 files (9 finders + 4 navigators) with calls to the wrapper
- Fix bug in `finders/stimulus.lua` where prompt title was incorrectly "System tests" instead of "Stimulus controllers"
- Update README to reflect new picker options
## Usage
```lua
-- Default (telescope, backward compatible)
require("ror").setup()
-- Use snacks picker instead
require("ror").setup({ picker = "snacks" })
```
## Changes
| File | Change |
|------|--------|
| `lua/ror/config.lua` | Added `picker = "telescope"` to defaults |
| `lua/ror/picker.lua` | **New** — picker wrapper dispatching to telescope, snacks, or vim.ui.select fallback |
| `lua/ror/finders/*.lua` (9 files) | Replaced inline telescope boilerplate with `require("ror.picker").pick()` |
| `lua/ror/navigators/*.lua` (4 files) | Replaced inline telescope boilerplate with `require("ror.picker").pick()` |
| `README.md` | Updated dependencies and setup docs |
## Test Plan
- [x] With `picker = "telescope"` (default): all finders and navigators work identically to before
- [x] With `picker = "snacks"`: all finders and navigators open with snacks.picker UI, file preview works, selecting a file opens it
- [x] With snacks not installed and `picker = "snacks"`: falls back to `vim.ui.select` with a warning notification